### PR TITLE
Add job using pdf upload

### DIFF
--- a/talent_link/lib/widgets/after_login_pages/organization_hom_tabs/profile_tab_items/add_new_job_screen.dart
+++ b/talent_link/lib/widgets/after_login_pages/organization_hom_tabs/profile_tab_items/add_new_job_screen.dart
@@ -347,7 +347,7 @@ class _AddNewJobScreenState extends State<AddNewJobScreen>
       );
       request.headers['Authorization'] = 'Bearer ${widget.token}';
       request.files.add(
-        await http.MultipartFile.fromPath('jobFile', selectedFilePath!),
+        await http.MultipartFile.fromPath('file', selectedFilePath!),
       );
 
       final response = await request.send();


### PR DESCRIPTION
The user can now upload the file that has the description of the job, then the AI will analyze it and add it automatically 
Also, there is an option to write the description as text and send it to AI to add the job.
