### PR TITLE
Enhance profile tab with organization data and follower counts

### DIFF
--- a/talent_link/lib/widgets/after_login_pages/home_page_tabs/profile_tab_sections/post_sections/profile_widget_for_another_users.dart
+++ b/talent_link/lib/widgets/after_login_pages/home_page_tabs/profile_tab_sections/post_sections/profile_widget_for_another_users.dart
@@ -109,6 +109,7 @@ class _ProfileWidgetForAnotherUsersState
       );
       setState(() {
         organizationData = orgData;
+        print('Organization Data: $organizationData');
         fullName = orgData['name'];
         uploadedImageUrl = orgData['avatarUrl'];
         username = orgData['username'];
@@ -705,6 +706,27 @@ class _ProfileWidgetForAnotherUsersState
                                       ),
                                     ),
                                   ),
+                                  Padding(
+                                    padding: EdgeInsets.only(top: 10),
+
+                                    child: Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: [
+                                        _buildCountWidget(
+                                          followersCount,
+                                          'Followers',
+                                          true,
+                                        ),
+                                        const SizedBox(width: 24),
+                                        _buildCountWidget(
+                                          followingCount,
+                                          'Following',
+                                          false,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
                                 ],
                                 const SizedBox(height: 16),
                                 if (!isOrganization) ...[
@@ -896,8 +918,9 @@ class _ProfileWidgetForAnotherUsersState
                       if (isOrganization) ...[
                         // Organization Info Cards
                         _buildOrganizationInfoCard(
-                          "About",
-                          organizationData?['description'],
+                          'About',
+                          organizationData?['description'] ??
+                              'No description provided',
                           Icons.description_outlined,
                         ),
                         _buildOrganizationInfoCard(


### PR DESCRIPTION
- Added functionality to fetch and display organization data, including description, industry, website, and email, with default values if missing.
- Implemented follower and following count widgets that navigate to a followers list screen.
- Updated UI to include organization posts section, displaying the latest post with a link to view all posts.
- Improved error handling during data fetching processes for better user experience.